### PR TITLE
Fix svelte/valid-compile error on Printful settings (lint + check are red on main)

### DIFF
--- a/src/routes/admin/settings/printful/+page.svelte
+++ b/src/routes/admin/settings/printful/+page.svelte
@@ -211,12 +211,21 @@
         <details class="update-key">
           <summary>Update API key</summary>
           <div class="key-form">
-            <input
-              type={showKey ? 'text' : 'password'}
-              bind:value={apiKey}
-              placeholder="Paste new API key"
-              class="key-input"
-            />
+            {#if showKey}
+              <input
+                type="text"
+                bind:value={apiKey}
+                placeholder="Paste new API key"
+                class="key-input"
+              />
+            {:else}
+              <input
+                type="password"
+                bind:value={apiKey}
+                placeholder="Paste new API key"
+                class="key-input"
+              />
+            {/if}
             <button class="toggle-visibility" on:click={() => (showKey = !showKey)} type="button">
               {showKey ? 'Hide' : 'Show'}
             </button>
@@ -239,13 +248,23 @@
           </a>. Create a store-level token with at least <em>sync products</em> read access.
         </p>
         <div class="key-form">
-          <input
-            type={showKey ? 'text' : 'password'}
-            bind:value={apiKey}
-            placeholder="Paste your Printful API key"
-            class="key-input"
-            on:keydown={(e) => e.key === 'Enter' && handleConnect()}
-          />
+          {#if showKey}
+            <input
+              type="text"
+              bind:value={apiKey}
+              placeholder="Paste your Printful API key"
+              class="key-input"
+              on:keydown={(e) => e.key === 'Enter' && handleConnect()}
+            />
+          {:else}
+            <input
+              type="password"
+              bind:value={apiKey}
+              placeholder="Paste your Printful API key"
+              class="key-input"
+              on:keydown={(e) => e.key === 'Enter' && handleConnect()}
+            />
+          {/if}
           <button class="toggle-visibility" on:click={() => (showKey = !showKey)} type="button">
             {showKey ? 'Hide' : 'Show'}
           </button>


### PR DESCRIPTION
## Which issue this closes

**None.** This does not close an open issue — it fixes a compile error on `main` that makes the repo fail its own quality gate.

## Why

`main` currently fails `npm run lint` and `npm run check`:

```
src/routes/admin/settings/printful/+page.svelte
  215:15  error  'type' attribute cannot be dynamic if input uses two-way binding(invalid-type)  svelte/valid-compile
```

Svelte 4 does not allow a dynamic `type` attribute on an `<input>` that also uses `bind:value`. Both API-key fields in the Printful settings page do exactly that.

This has a knock-on effect worth flagging: `prepare` is `format && lint && check && test`, and npm runs `prepare` on install — so **`npm install` on a fresh clone of `main` exits non-zero**, which is the first command in the README's own Quick Setup.

## What I changed

One file, `src/routes/admin/settings/printful/+page.svelte`. Each of the two API-key inputs is split into explicit `text` / `password` branches behind `{#if showKey}`, preserving the placeholder, `class`, `bind:value`, and the Enter-to-submit handler on the second field.

## Gate commands I ran, and what I observed

Node v26.7.0, npm 11.19.0, macOS (arm64).

| Command | Baseline on `upstream/main` | On this branch |
| --- | --- | --- |
| `npm run lint` | **EXIT 1** — prettier clean, 1 eslint error (above) | **EXIT 0** |
| `npm run check` | **EXIT 1** — `svelte-check found 1 error and 2 warnings in 3 files` | **EXIT 0** — `svelte-check found 0 errors and 2 warnings in 2 files` |
| `npm run test` | EXIT 1 — `17 failed \| 3342 passed \| 16 skipped` | EXIT 1 — `17 failed \| 3342 passed \| 16 skipped` (unchanged) |

`npx prettier --check src/routes/admin/settings/printful/+page.svelte` → EXIT 0.

The 17 test failures are **pre-existing and unrelated** to this change — they are a Node 22+ `localStorage` problem, addressed separately in the companion PR. The count is byte-identical before and after, so this change causes no test regression.

The 2 remaining `svelte-check` warnings are pre-existing CSS `line-clamp` compatibility warnings, untouched here.

## What I did NOT verify

- **No browser render.** I did not run the dev server or load `/admin/settings/printful`.
- **No exercise of the Printful connect flow** — no API key, no D1 database, no Printful account.
- **Behavioural difference worth a maintainer's eye:** `{#if}/{:else}` destroys and recreates the input element when Show/Hide is clicked. The bound `apiKey` value survives (it's the bound variable), but **keyboard focus is lost on toggle**, where the dynamic-attribute version would have kept it. If focus retention matters, the alternative is a single input with `type="text"` plus a CSS/`-webkit-text-security` masking approach, or an `action` that sets `type` imperatively — I did not implement either, since this fix is the minimal one that satisfies the compiler.

---

Commits on this branch (against `starspacegroup/hermes@main`):

- `a3692ab` Fix invalid dynamic input type with two-way binding on Printful settings
